### PR TITLE
Add Image3D to Industry & Companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ A key finding of this survey is that existing benchmarks systematically overesti
 | Tencent | Hunyuan3D | Open + Closed | [3d.hunyuan.tencent.com](https://3d.hunyuan.tencent.com/) |
 | ByteDance | MVDream | Open | - |
 | Meshy AI | Meshy 5 | Closed | [meshy.ai](https://www.meshy.ai/) |
+| Image3D | Image-to-3D Generator | Closed | [image3d.io](https://image3d.io/) |
 | Deemos | Rodin Gen 1.5 | Closed | [hyperhuman.deemos.com](https://hyperhuman.deemos.com/) |
 | DreamTech | - | Closed | [dreamtech.com](https://www.dreamtech.com/) |
 | Luma AI | Genie | Closed | [lumalabs.ai](https://lumalabs.ai/) |


### PR DESCRIPTION
## Summary

- Adds [Image3D](https://image3d.io/) to the **Industry & Companies** section.
- Image3D provides image-to-3D generation with GLB, OBJ, STL, and PLY exports.
- Follows the existing table format used in the v2 Company section.

## Why it fits

Image3D is a closed web tool for converting images into downloadable 3D assets. It is relevant to the production-ready asset generation scope because it focuses on practical export workflows for web 3D previews, product pages, and STL-oriented workflows.

## Test plan

- [x] Entry follows the existing Company section table format.
- [x] No duplicate Image3D entry found.
- [x] Description is concise and relevant to AIGC 3D.
